### PR TITLE
Add concept of serverUnique columns to avoid duplicate db entries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ class Thing: BaseModel {
 
   static let sqlTableName = "Thing"
   static let columns = [
-    ColumnMeta(name: "tid", type: .text, primaryKey: true),
-    ColumnMeta(name: "name", type: .text, primaryKey: false)
+    ColumnMeta(name: "tid", type: .text, constraint: .primary),
+    ColumnMeta(name: "name", type: .text)
   ]
 }
 

--- a/Sources/DBManager.swift
+++ b/Sources/DBManager.swift
@@ -7,6 +7,8 @@ public enum DBError: Error {
 
 public enum QueryError: Error {
   case failed(errorCode: Int)
+  case missingKey
+  case keyIsNull(fieldName: String)
 }
 
 public enum StatementType {

--- a/Sources/Model.swift
+++ b/Sources/Model.swift
@@ -16,7 +16,7 @@ public struct ColumnConstraint: OptionSet {
   }
   
   public static let primary = ColumnConstraint(rawValue: 1)
-  public static let serverUnique = ColumnConstraint(rawValue: 2)
+  public static let unique = ColumnConstraint(rawValue: 2)
   public static let none = ColumnConstraint(rawValue: 4)
 }
 
@@ -232,7 +232,7 @@ extension ModelDef {
     } catch QueryError.failed(let code) {
       if code == 19 && !self.existsInDatabase { //unique constraint error on adding new object
         do {
-          let uniqueKeyData = try self.getKeyData(constraint: .serverUnique, fallbackConstraint: .primary)
+          let uniqueKeyData = try self.getKeyData(constraint: .unique, fallbackConstraint: .primary)
           print("Update object with data that already exists in the db for '\(localTableName)'. \(uniqueKeyData.whereClause) >> \(uniqueKeyData.values)")
           self.reloadWithData(uniqueKeyData)
           

--- a/Sources/Model.swift
+++ b/Sources/Model.swift
@@ -8,17 +8,34 @@ public enum ColumnType {
   case text, real, int, bool, date, array, dictionary
 }
 
+public struct ColumnConstraint: OptionSet {
+  public let rawValue: Int
+  
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+  
+  public static let primary = ColumnConstraint(rawValue: 1)
+  public static let serverUnique = ColumnConstraint(rawValue: 2)
+  public static let none = ColumnConstraint(rawValue: 4)
+}
 
 public struct ColumnMeta {
   let name: String
   let type: ColumnType
-  let primaryKey: Bool
+  let constraint: ColumnConstraint
   
-  public init(name: String, type: ColumnType, primaryKey: Bool) {
+  public init(name: String, type: ColumnType, constraint: ColumnConstraint = .none) {
     self.name = name
     self.type = type
-    self.primaryKey = primaryKey
+    self.constraint = constraint
   }
+}
+
+public struct KeyData {
+  let whereClause: String
+  let values: Array<Any>
+  let columns: Array<ColumnMeta>
 }
 
 
@@ -156,28 +173,36 @@ extension ModelDef {
 
     switch existsInDatabase {
       case true: //Update
-        let primaryKeyMeta = getPrimaryKeyColumn()
-        guard let primaryKeyValue = self.value(forKey: primaryKeyMeta.name) else {
-          preconditionFailure("Primary key field '\(primaryKeyMeta.name)' must contain a value: \(sqlTableName)")
-        }
-
-        var setClauses = [String]()
-
-        for meta in columns {
-          if !meta.primaryKey {
-            let val = getValueToWriteToDB(meta)
-            if let val = val as? NSObject , val == NSNull() {
-              setClauses.append("\(meta.name) = NULL")
-
-            } else {
-              values.append(val)
-              setClauses.append("\(meta.name) = ?")
+        do {
+          let primaryKeyData = try getKeyData(constraint: .primary)
+          
+          var setClauses = [String]()
+          
+          for meta in type(of: self).columns {
+            if !meta.constraint.contains(.primary) {
+              let val = getValueToWriteToDB(meta)
+              if let val = val as? NSObject , val == NSNull() {
+                setClauses.append("\(meta.name) = NULL")
+                
+              } else {
+                values.append(val)
+                setClauses.append("\(meta.name) = ?")
+              }
             }
           }
+          
+          values.append(contentsOf: primaryKeyData.values)
+          return StatementParts(sql: "UPDATE \(sqlTableName) SET \(setClauses.joined(separator: ",")) WHERE \(primaryKeyData.whereClause)", values: values, type: .update)
+          
+        } catch QueryError.keyIsNull(let name) {
+          preconditionFailure("Primary key field '\(name)' must contain a value: \(sqlTableName)")
+          
+        } catch QueryError.missingKey {
+          preconditionFailure("Primary key field must be defined for table: \(sqlTableName)")
+          
+        } catch {
+          preconditionFailure("Error creating update statement: \(error)")
         }
-
-        values.append(primaryKeyValue)
-        return StatementParts(sql: "UPDATE \(sqlTableName) SET \(setClauses.joined(separator: ",")) WHERE \(primaryKeyMeta.name) = ?", values: values, type: .update)
 
       case false: //New Instance
         var names = [String]()
@@ -204,15 +229,21 @@ extension ModelDef {
         self.existsInDatabase = true
       }
 
-    } catch QueryError.failed(let code){
+    } catch QueryError.failed(let code) {
       if code == 19 && !self.existsInDatabase { //unique constraint error on adding new object
-        let meta = self.getPrimaryKeyColumn()
-        if let primaryKeyValue = self.value(forKey: meta.name) {
-          print("Update object with data that already exists in the db for '\(localTableName)'.\(meta.name)=\(primaryKeyValue).")
-          self.reloadWithData(meta, primaryKeyValue: primaryKeyValue)
-
-        } else {
-          print("Failed to load duplicate object from db because missing primary key value: \(localTableName).\(meta.name)")
+        do {
+          let uniqueKeyData = try self.getKeyData(constraint: .serverUnique, fallbackConstraint: .primary)
+          print("Update object with data that already exists in the db for '\(localTableName)'. \(uniqueKeyData.whereClause) >> \(uniqueKeyData.values)")
+          self.reloadWithData(uniqueKeyData)
+          
+        } catch QueryError.missingKey {
+          preconditionFailure("Failed to load duplicate object from db because no unique key defined: \(localTableName)")
+          
+        } catch QueryError.keyIsNull(let name) {
+          print("Failed to load duplicate object from db because missing unique key value: \(localTableName).\(name)")
+          
+        } catch {
+          print("Failed to update duplicate object: \(error)")
         }
       }
 
@@ -223,58 +254,68 @@ extension ModelDef {
 
   public func reload() {
     precondition(existsInDatabase, "Can't reload an object that doesn't yet exist in the database.")
-
-    let meta = getPrimaryKeyColumn()
-    guard let primaryKeyValue = self.value(forKey: meta.name) else {
-      preconditionFailure("Primary key field '\(meta.name)' must contain a value: \(type(of: self).sqlTableName)")
+    
+    do {
+      let primaryKeyData = try getKeyData(constraint: .primary)
+      reloadWithData(primaryKeyData)
+      
+    } catch QueryError.missingKey {
+      preconditionFailure("Every table must define one or more primary key columns: \(type(of: self).sqlTableName)")
+      
+    } catch QueryError.keyIsNull(let name) {
+      preconditionFailure("Primary key field '\(name)' must contain a value: \(type(of: self).sqlTableName)")
+      
+    } catch {
+      preconditionFailure("Failed to reload: \(error)")
     }
-
-    reloadWithData(meta, primaryKeyValue: primaryKeyValue)
   }
 
   public func delete() {
     if !existsInDatabase {
       return
     }
-
-    let meta = getPrimaryKeyColumn()
+    
     let localTableName = type(of: self).sqlTableName
-    guard let primaryKeyValue = self.value(forKey: meta.name) else {
-      preconditionFailure("Primary key field '\(meta.name)' must contain a value: \(localTableName)")
-    }
-
-    let statement = StatementParts(sql: "DELETE FROM \(localTableName) WHERE \(meta.name) = ?", values: [primaryKeyValue], type: .update)
-
     do {
+      let primaryKeyData = try getKeyData(constraint: .primary)
+      let statement = StatementParts(sql: "DELETE FROM \(localTableName) WHERE \(primaryKeyData.whereClause)", values: primaryKeyData.values, type: .update)
+      
       try DBManager.executeStatement(statement) { _ in }
       self.isDeleted = true
+      
+    } catch QueryError.missingKey {
+      preconditionFailure("Every table must define one or more primary key columns: \(type(of: self).sqlTableName)")
+      
+    } catch QueryError.keyIsNull(let name) {
+      preconditionFailure("Primary key field '\(name)' must contain a value: \(type(of: self).sqlTableName)")
+      
     } catch {
-      print("Failed to delete object \(primaryKeyValue) from table \(localTableName): \(error)")
+      print("Failed to delete object from table \(localTableName): \(error)")
     }
-
+    
     (self as? ModelType)?.didDelete()
   }
 
   //MARK: Private helpers
-
-  private func reloadWithData(_ meta: ColumnMeta, primaryKeyValue: Any) {
+  
+  fileprivate func reloadWithData(_ keyData: KeyData) {
     do {
       let statement = StatementParts(
-        sql: "SELECT * FROM \(type(of: self).sqlTableName) WHERE \(meta.name) = ? LIMIT 1",
-        values: [primaryKeyValue],
+        sql: "SELECT * FROM \(type(of: self).sqlTableName) WHERE \(keyData.whereClause) LIMIT 1",
+        values: keyData.values,
         type: .query)
       try DBManager.executeStatement(statement, resultHandler: { (result) in
         guard let result = result else {
           print("Failed to reload object from db cache")
           return
         }
-
+        
         var foundMatch = false
         while result.next() {
           type(of: self).populateInstance(result: result, updateInstance: self as! ModelType)
           foundMatch = true
         }
-
+        
         if !foundMatch {
           self.isDeleted = true
         }
@@ -311,14 +352,43 @@ extension ModelDef {
     }
     return val
   }
-
-  private func getPrimaryKeyColumn() -> ColumnMeta {
-    for meta in type(of: self).columns {
-      if meta.primaryKey {
-        return meta
+  
+  fileprivate func getKeyData(constraint: ColumnConstraint, fallbackConstraint: ColumnConstraint? = nil) throws -> KeyData {
+    func readKeyData(constraint: ColumnConstraint) throws -> KeyData {
+      var keys = Array<ColumnMeta>()
+      var values = Array<Any>()
+      
+      for meta in type(of: self).columns {
+        if meta.constraint.contains(constraint) {
+          guard let keyValue = self.value(forKey: meta.name) else {
+            throw QueryError.keyIsNull(fieldName: meta.name)
+          }
+          keys.append(meta)
+          values.append(keyValue)
+        }
+      }
+      guard keys.count > 0 else {
+        throw QueryError.missingKey
+      }
+      
+      let whereClause = keys.map({ (key) -> String in
+        return "\(key.name) = ?"
+      }).joined(separator: " AND ")
+      
+      return KeyData(whereClause: whereClause, values: values, columns: keys)
+    }
+    
+    do {
+      let keyData = try readKeyData(constraint: constraint)
+      return keyData
+      
+    } catch {
+      if let fallbackConstraint = fallbackConstraint {
+        return try readKeyData(constraint: fallbackConstraint)
+      } else {
+        throw error
       }
     }
-    preconditionFailure("Every table must define a primary key column: \(type(of: self).sqlTableName)")
   }
 
   private static func populateInstance(result: FMResultSet, updateInstance: ModelType) -> Void {

--- a/sModel.podspec
+++ b/sModel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "sModel"
-  s.version      = "0.1.3"
+  s.version      = "0.2.0"
   s.summary      = "sModel is a lightweight object mapper for sqlite."
 
   s.description  = <<-DESC

--- a/sModel.xcodeproj/project.pbxproj
+++ b/sModel.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BD1737811DE4BA5E007171D0 /* sModelPublicInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1737801DE4BA5E007171D0 /* sModelPublicInterfaceTests.swift */; };
+		BD297D671E200392003D2D29 /* BatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD297D661E200392003D2D29 /* BatchTests.swift */; };
 		BD3E92681DDCCB900089EBEA /* sModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD3E925E1DDCCB8F0089EBEA /* sModel.framework */; };
 		BD3E926F1DDCCB900089EBEA /* sModel.h in Headers */ = {isa = PBXBuildFile; fileRef = BD3E92611DDCCB8F0089EBEA /* sModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD3E927A1DDCCBA20089EBEA /* DBManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3E92781DDCCBA20089EBEA /* DBManager.swift */; };
@@ -52,6 +53,7 @@
 
 /* Begin PBXFileReference section */
 		BD1737801DE4BA5E007171D0 /* sModelPublicInterfaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sModelPublicInterfaceTests.swift; sourceTree = "<group>"; };
+		BD297D661E200392003D2D29 /* BatchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchTests.swift; sourceTree = "<group>"; };
 		BD3E925E1DDCCB8F0089EBEA /* sModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = sModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD3E92611DDCCB8F0089EBEA /* sModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sModel.h; sourceTree = "<group>"; };
 		BD3E92621DDCCB8F0089EBEA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 		BD3E926B1DDCCB900089EBEA /* sModelTests */ = {
 			isa = PBXGroup;
 			children = (
+				BD297D661E200392003D2D29 /* BatchTests.swift */,
 				BD3E929A1DDE18BA0089EBEA /* DBManagerMultiDBTests.swift */,
 				BD3E92941DDCF0EE0089EBEA /* DBManagerSetupTests.swift */,
 				BD3E92981DDCF79A0089EBEA /* DBManagerUsageTests.swift */,
@@ -310,6 +313,7 @@
 			files = (
 				BD3E927F1DDCCBB40089EBEA /* ModelTests.swift in Sources */,
 				BD3E929B1DDE18BA0089EBEA /* DBManagerMultiDBTests.swift in Sources */,
+				BD297D671E200392003D2D29 /* BatchTests.swift in Sources */,
 				BD3E92801DDCCBB40089EBEA /* MultiThreadTests.swift in Sources */,
 				BD3E92951DDCF0EE0089EBEA /* DBManagerSetupTests.swift in Sources */,
 				BD1737811DE4BA5E007171D0 /* sModelPublicInterfaceTests.swift in Sources */,

--- a/sModel.xcodeproj/xcshareddata/xcbaselines/BD3E92661DDCCB900089EBEA.xcbaseline/EA1FE392-8294-4C76-9916-7C75F6118209.plist
+++ b/sModel.xcodeproj/xcshareddata/xcbaselines/BD3E92661DDCCB900089EBEA.xcbaseline/EA1FE392-8294-4C76-9916-7C75F6118209.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>ModelTests</key>
+		<dict>
+			<key>testPerformanceLotsOfInserts()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.079639</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Jan 6, 2017, 3:33:11 PM</string>
+				</dict>
+			</dict>
+			<key>testPerformanceLotsOfInsertsReads()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.48855</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Jan 6, 2017, 3:33:11 PM</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/sModel.xcodeproj/xcshareddata/xcbaselines/BD3E92661DDCCB900089EBEA.xcbaseline/EA1FE392-8294-4C76-9916-7C75F6118209.plist
+++ b/sModel.xcodeproj/xcshareddata/xcbaselines/BD3E92661DDCCB900089EBEA.xcbaseline/EA1FE392-8294-4C76-9916-7C75F6118209.plist
@@ -11,9 +11,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.079639</real>
+					<real>0.10588</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Jan 6, 2017, 3:33:11 PM</string>
+					<string>Jan 9, 2017, 10:53:38 AM</string>
 				</dict>
 			</dict>
 			<key>testPerformanceLotsOfInsertsReads()</key>
@@ -21,9 +21,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.48855</real>
+					<real>0.74457</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Jan 6, 2017, 3:33:11 PM</string>
+					<string>Jan 9, 2017, 10:53:38 AM</string>
 				</dict>
 			</dict>
 		</dict>

--- a/sModel.xcodeproj/xcshareddata/xcbaselines/BD3E92661DDCCB900089EBEA.xcbaseline/Info.plist
+++ b/sModel.xcodeproj/xcshareddata/xcbaselines/BD3E92661DDCCB900089EBEA.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>EA1FE392-8294-4C76-9916-7C75F6118209</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2500</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro11,4</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone9,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/sModel/Info.plist
+++ b/sModel/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.3</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.3</string>
+	<string>0.2.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/sModelTests/0001.sql
+++ b/sModelTests/0001.sql
@@ -1,7 +1,10 @@
 CREATE TABLE "Thing" (
-  "tid" TEXT PRIMARY KEY,
+  "localId" TEXT PRIMARY KEY,
+  "tid" TEXT,
   "name" TEXT
 );
+
+CREATE UNIQUE INDEX "main"."INDEX_tid" ON Thing ("tid");
 
 CREATE TABLE "Animal" (
   "aid" TEXT PRIMARY KEY,

--- a/sModelTests/0002.sql
+++ b/sModelTests/0002.sql
@@ -3,7 +3,5 @@ CREATE TABLE "Place" (
   "name" TEXT
 );
 
-ALTER TABLE Thing
-ADD other INTEGER;
-ALTER TABLE Thing
-ADD otherDouble REAL;
+ALTER TABLE Thing ADD other INTEGER;
+ALTER TABLE Thing ADD otherDouble REAL;

--- a/sModelTests/BatchTests.swift
+++ b/sModelTests/BatchTests.swift
@@ -1,0 +1,67 @@
+//
+//  BatchTests.swift
+//  sModel
+//
+//  Created by Stephen Lynn on 1/6/17.
+//  Copyright © 2017 FamilySearch. All rights reserved.
+//
+
+import XCTest
+@testable import sModel
+
+class BatchTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    
+    var paths = DBManager.getDBDefFiles(bundle: Bundle(for: type(of: self)))!
+    paths.sort()
+    
+    try! DBManager.open(nil, dbDefFilePaths: paths)
+  }
+  
+  override func tearDown() {
+    DBManager.close()
+    super.tearDown()
+  }
+  
+  //MARK: Happy path
+  
+  func testBatchInserts() {
+    DBManager.shouldReplaceDuplicates = true
+    
+    let statementsA = generateInsertStatements(count: 10, prefix: "A")
+    let statementsB = generateInsertStatements(count: 10, prefix: "B")
+    
+    try! DBManager.executeStatements(statementsA) { (results) in
+      XCTAssertEqual(10, results.count)
+    }
+    
+    try! DBManager.executeStatements(statementsB) { (results) in
+      XCTAssertEqual(10, results.count)
+    }
+    
+    guard let thing1 = Thing.firstInstanceWhere("tid = ?", params: "tid1") else {
+      XCTFail("Thing with tid = 'tid1' should exist")
+      return
+    }
+    
+    XCTAssertEqual("B thing 1", thing1.name)
+    
+    DBManager.shouldReplaceDuplicates = false
+  }
+  
+  private func generateInsertStatements(count: Int, prefix: String) -> Array<StatementParts> {
+    var statements = [StatementParts]()
+    
+    for i in 0..<count {
+      let thing = Thing()
+      thing.tid = "tid\(i)"
+      thing.name = "\(prefix) thing \(i)"
+      
+      let statement = thing.createSaveStatement()
+      statements.append(statement)
+    }
+    
+    return statements
+  }
+}

--- a/sModelTests/TestModels.swift
+++ b/sModelTests/TestModels.swift
@@ -13,7 +13,7 @@ class Thing: BaseModel {
   static let sqlTableName = "Thing"
   static let columns = [
     ColumnMeta(name: "localId", type: .text, constraint: .primary),
-    ColumnMeta(name: "tid", type: .text, constraint: .serverUnique),
+    ColumnMeta(name: "tid", type: .text, constraint: .unique),
     ColumnMeta(name: "name", type: .text),
     ColumnMeta(name: "other", type: .int),
     ColumnMeta(name: "otherDouble", type: .real)

--- a/sModelTests/TestModels.swift
+++ b/sModelTests/TestModels.swift
@@ -2,6 +2,7 @@ import Foundation
 import sModel
 
 class Thing: BaseModel {
+  var localId = BaseModel.generateUUID()
   var tid = ""
   var name: String? = nil
   var other = 0
@@ -11,10 +12,11 @@ class Thing: BaseModel {
 
   static let sqlTableName = "Thing"
   static let columns = [
-    ColumnMeta(name: "tid", type: .text, primaryKey: true),
-    ColumnMeta(name: "name", type: .text, primaryKey: false),
-    ColumnMeta(name: "other", type: .int, primaryKey: false),
-    ColumnMeta(name: "otherDouble", type: .real, primaryKey: false)
+    ColumnMeta(name: "localId", type: .text, constraint: .primary),
+    ColumnMeta(name: "tid", type: .text, constraint: .serverUnique),
+    ColumnMeta(name: "name", type: .text),
+    ColumnMeta(name: "other", type: .int),
+    ColumnMeta(name: "otherDouble", type: .real)
   ]
 
   override func didDelete() {
@@ -38,12 +40,12 @@ class Animal: BaseModel {
 
   static let sqlTableName = "Animal"
   static let columns = [
-    ColumnMeta(name: "aid", type: .text, primaryKey: true),
-    ColumnMeta(name: "name", type: .text, primaryKey: false),
-    ColumnMeta(name: "living", type: .int, primaryKey: false),
-    ColumnMeta(name: "lastUpdated", type: .date, primaryKey: false),
-    ColumnMeta(name: "ids", type: .array, primaryKey: false),
-    ColumnMeta(name: "props", type: .dictionary, primaryKey: false)
+    ColumnMeta(name: "aid", type: .text, constraint: .primary),
+    ColumnMeta(name: "name", type: .text),
+    ColumnMeta(name: "living", type: .int),
+    ColumnMeta(name: "lastUpdated", type: .date),
+    ColumnMeta(name: "ids", type: .array),
+    ColumnMeta(name: "props", type: .dictionary)
   ]
 }
 


### PR DESCRIPTION
This change supports adding uniqueness constraints to fields other than
the primary key field.  This is helpful when your primary key is a value
that only exists in your local database but other columns contain keys
that exist on the server.  In cases were you are reading data from the
server and attempt to insert an entry that violates a server key constraint,
you want to be able reload your instance with the existing row entry that
matches the given server key.  You may now define with column(s) define your
server key by annotating columns as having a constraint `.serverUnique`.